### PR TITLE
[fix] 채팅 namespace 추가 및 chat-rooms/me 404 에러 수정

### DIFF
--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -1,16 +1,33 @@
 import {
+  MessageBody,
   SubscribeMessage,
   WebSocketGateway,
   WebSocketServer,
 } from '@nestjs/websockets';
+import { Socket } from 'net';
 import { Server } from 'socket.io';
 
-@WebSocketGateway()
+@WebSocketGateway(3600, {
+  cors: ['localhost:3000', 'https://www.meething.net'],
+  namespace: 'chat-rooms',
+})
 export class ChatGateway {
   @WebSocketServer()
   public io: Server;
+
+  handleConnection(client: any) {
+    const socketId = client.id;
+    this.io.emit('connection', { state: 'success', socketId });
+  }
+
   @SubscribeMessage('message')
-  handleMessage(client: any, payload: any): string {
-    return 'Hello world!';
+  handleMessage(client: Socket, query: string) {
+    //
+  }
+
+  @SubscribeMessage('events')
+  handleEvent(@MessageBody() data: string): string {
+    console.log(data);
+    return data;
   }
 }

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -8,7 +8,6 @@ import { Socket } from 'net';
 import { Server } from 'socket.io';
 
 @WebSocketGateway(3600, {
-  cors: ['localhost:3000', 'https://www.meething.net'],
   namespace: 'chat-rooms',
 })
 export class ChatGateway {
@@ -27,7 +26,6 @@ export class ChatGateway {
 
   @SubscribeMessage('events')
   handleEvent(@MessageBody() data: string): string {
-    console.log(data);
     return data;
   }
 }

--- a/src/common/mongo.repository.ts
+++ b/src/common/mongo.repository.ts
@@ -34,11 +34,6 @@ export abstract class BaseRepository<TDocument extends BaseSchema> {
 
   async findOne(filterQuery: FilterQuery<TDocument>) {
     const document = await this.model.findOne(filterQuery, {}, { lean: true });
-
-    if (!document) {
-      this.logger.warn('Document not found with filterQuery', filterQuery);
-      throw new NotFoundException('Document not found.');
-    }
     return document;
   }
 
@@ -52,12 +47,6 @@ export abstract class BaseRepository<TDocument extends BaseSchema> {
       lean: true,
       new: true,
     });
-
-    if (!document) {
-      this.logger.warn(`Document not found with filterQuery:`, filterQuery);
-      throw new NotFoundException('Document not found.');
-    }
-
     return document;
   }
 

--- a/src/room/room.service.ts
+++ b/src/room/room.service.ts
@@ -84,6 +84,8 @@ export class RoomService {
 
   public async search(userId: string) {
     const user = await this.userService.findById(userId);
+    if (!user) return [];
+
     const rooms = user.rooms.map((room) => room.room);
     const meetings = await this.meetingService.findByIdIn(
       rooms.map((room) => room.meeting.id),


### PR DESCRIPTION
- `/chat-rooms/me` api에서 해당 유저에 채팅방이 없으면 404를 뱉게 되어있는데, 200에 빈배열이 내려가는게 맞을 것 같아 수정했습니다.
- moogo 레포에서 전체적으로 document가 없으면 404를 뱉고 있는거 같아서 없앴고, find해서 찾는 컨트롤러나 서비스 단에서 예외 처리를 해주는게 맞는것 같습니다